### PR TITLE
include <QVariant> in qtdocktitle.h

### DIFF
--- a/lib/qtdocktile.h
+++ b/lib/qtdocktile.h
@@ -27,6 +27,7 @@
 
 #include "qtdocktile_global.h"
 #include <QObject>
+#include <QVariant>
 #include <QIcon>
 
 class QMenu;


### PR DESCRIPTION
без этого инклюда не собиралось под win(vs2010), linux (gcc 4.6.1)
