### PR TITLE
Turn cmake CMP0002 policy to OLD for build plugin in qutim buildtree wit...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
+    cmake_policy(SET CMP0002 OLD)
 endif(COMMAND cmake_policy)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
...h new cmake. Alternatively uninstall target may be changed (renamed?)
